### PR TITLE
[A_printf] Use \r\n instead of \n

### DIFF
--- a/winter/Code/shared/adastral_defs.cpp
+++ b/winter/Code/shared/adastral_defs.cpp
@@ -11,7 +11,11 @@ void A_printf(const char *const format, ...)
     va_start(argptr, format);
     vfprintf(stdout, format, argptr);
     va_end(argptr);
+#if _WIN32
+    printf("\r\n"):
+#else
     printf("\n"); // kinda dumb, but this makes parity with the godot ver. ideally it'd be the other way around, but there's no way to knock off the \n in godot's case.
+#endif
 #else
     // #pragma warning ("GODOT ENABLED.")
     va_list argptr;


### PR DESCRIPTION
Title is self-explanatory. `\r\n` is used instead of `\n` when building for Windows in the `A_printf` function.

_Should_ fix the issue of consolespam with libtorrent
![screenshot](https://res.kate.pet/upload/998994ba5e18/Discord_QKiMIaem9i.png)