### PR TITLE
fix symlink (installing into other directories) + refactor to better support this

### DIFF
--- a/winter/Code/emley/kachemak/kachemak.cpp
+++ b/winter/Code/emley/kachemak/kachemak.cpp
@@ -118,10 +118,10 @@ int Kachemak::verify()
     std::stringstream sig_url_full;
     sig_url_full << source_url << installed_km_version.value().signature;
     // Data path for current install
-    std::filesystem::path dataDir_path = sourcemod_path / folder_name;
+    std::filesystem::path data_dir_path = sourcemod_path / folder_name;
     std::stringstream heal_url;
     heal_url << source_url << installed_km_version.value().file_name;
-    butler_verify(sig_url_full.str(), dataDir_path.string(), heal_url.str());
+    butler_verify(sig_url_full.str(), data_dir_path.string(), heal_url.str());
     force_verify = false;
     write_version();
     return 0;

--- a/winter/Code/emley/kachemak/kachemak.cpp
+++ b/winter/Code/emley/kachemak/kachemak.cpp
@@ -182,7 +182,7 @@ int Kachemak::update()
     return 0;
 }
 
-int Kachemak::install()
+int Kachemak::install(std::filesystem::path path)
 {
     std::optional<KachemakVersion> latest_version = get_latest_km_version();
     if (!latest_version)
@@ -203,50 +203,11 @@ int Kachemak::install()
         return download_status;
     }
     A_printf("[Kachemak/install] Download complete: extracting...");
-    std::filesystem::create_directory(sourcemod_path.string() / folder_name);
-    int ret = extract(latest_version.value().file_name, (sourcemod_path / folder_name).string(), latest_version.value().extract_size);
+    std::filesystem::create_directory(path.string() / folder_name);
+    int ret = extract(latest_version.value().file_name, (path / folder_name).string(), latest_version.value().extract_size);
     if (ret == 0)
     {
         A_printf("[Kachemak/install] Extraction done!");
-        installed_version_code = get_latest_version_code();
-        write_version();
-        return 0;
-    }
-    else
-    {
-        return 1;
-    }
-}
-
-int Kachemak::install_path(std::filesystem::path custom_path)
-{
-    std::optional<KachemakVersion> latest_version = get_latest_km_version();
-    if (!latest_version)
-    {
-        return 2;
-    }
-    int disk_space_status = free_space_check(latest_version.value().download_size, FreeSpaceCheckCategory::Temporary);
-    if (disk_space_status != 0)
-    {
-        return disk_space_status;
-    }
-    std::string download_uri = source_url + latest_version.value().download_url;
-    A_printf("[Kachemak/InstallInPath] Downloading via torrent...");
-    int download_status = torrent::libtorrent_download(download_uri, temp_path.string(), &event_system);
-    // std::filesystem::path path = net::download_to_temp(downloadUri, latestVersion.value().file_name,
-    // true,&event_system);
-    if (download_status != 0)
-    {
-        A_error("[Kachemak/InstallInPath] Download failed - ret val %d \n", download_status);
-        return download_status;
-    }
-    A_printf("[Kachemak/InstallInPath] Download complete: extracting...");
-    std::filesystem::create_directory(custom_path.string() / folder_name);
-    int ret = extract_path(latest_version.value().file_name, (custom_path / folder_name).string(), latest_version.value().extract_size);
-    // extract( path.string() , (sourcemod_path/ folder_name).string() , latestVersion.value().extract_size);
-    if (ret == 0)
-    {
-        A_printf("[Kachemak/InstallInPath] Extraction done!");
         installed_version_code = get_latest_version_code();
         write_version();
         return 0;

--- a/winter/Code/emley/kachemak/kachemak.hpp
+++ b/winter/Code/emley/kachemak/kachemak.hpp
@@ -37,12 +37,11 @@ class Kachemak : public Version
  public:
   Kachemak(const std::filesystem::path& sourcemod_path, const std::filesystem::path& folder_name,
            const std::string& source_url, const std::filesystem::path& butler_path);
-  virtual int install();
-  virtual int install_path(std::filesystem::path custom_path);
+  virtual int install(std::filesystem::path path);
   int free_space_check(const uintmax_t size, const FreeSpaceCheckCategory& category);
   int free_space_check_path(const uintmax_t size, const std::filesystem::path custom_path);
-  int update();
-  int verify();
+  virtual int update();
+  virtual int verify();
   int extract(const std::string& input_file, const std::string& output_directory, const size_t& size);
   int extract_path(const std::string& input_file, const std::string& output_directory, const size_t& size);
   std::string get_installed_version_tag();

--- a/winter/Code/emley/version/version.hpp
+++ b/winter/Code/emley/version/version.hpp
@@ -10,7 +10,7 @@ class Version
   Version(const std::filesystem::path& sourcemod_path, const std::filesystem::path& folder_name,
           const std::string& source_url);
   virtual int verify() = 0;
-  virtual int install() = 0;
+  virtual int install(std::filesystem::path path) = 0;
   const std::string& get_installed_version_code();
   std::string name;
   EventSystem event_system;  // we need to yoink it into palace and then sutton

--- a/winter/Code/palace/palace.cpp
+++ b/winter/Code/palace/palace.cpp
@@ -188,7 +188,15 @@ int palace::update_game(const std::string &game_name)
 int palace::update_game(const std::string &game_name,const std::string &install_path)
 {
     A_printf("[Palace/UpdateGame] Updating %s....", game_name.c_str());
-    // stub for now
+    if (server_games[game_name]->l1->get_installed_version_code().empty())
+    {
+        server_games[game_name]->l1->install(install_path);
+        std::filesystem::create_directory_symlink(install_path ,sourcemods_path / "game_name");
+    }
+    else
+    {
+        server_games[game_name]->l1->update();
+    }
     return 0;
 }
 

--- a/winter/Code/palace/palace.cpp
+++ b/winter/Code/palace/palace.cpp
@@ -171,7 +171,7 @@ int palace::update_game(const std::string &game_name)
     A_printf("[Palace/UpdateGame] Updating %s....", game_name.c_str());
     if (server_games[game_name]->l1->get_installed_version_code().empty())
     {
-        server_games[game_name]->l1->install();
+        server_games[game_name]->l1->install(sourcemods_path);
     }
     // else if(server_games[game_name]->l1->get_installed_version() == server_games[game_name]->l1->GetLatestVersion() ||
     // server_games[game_name]->l1->force_verify){
@@ -184,28 +184,15 @@ int palace::update_game(const std::string &game_name)
     return 0;
 }
 
-// creating the same function to accept in custom path names.
-int palace::update_game_with_path(const std::string &game_name, const std::string custom_path)
+
+int palace::update_game(const std::string &game_name,const std::string &install_path)
 {
-    A_printf("[Palace/UpdateGameWithPath] Updating %s....", game_name.c_str());
-
-    // First, we sanitize the path and try to convert it to std::filesystem::path variable.
-    const std::filesystem::path sanitized_path = std::filesystem::u8path(custom_path); // windows-specific thing that may work on linux, need to try on that
-
-    // Then we practically do the same thing except inserting the sanitized path to the overloaded install function.
-    if (server_games[game_name]->l1->get_installed_version_code().empty())
-    {
-        server_games[game_name]->l1->install_path(sanitized_path);
-    }
-    // else if(server_games[game_name]->l1->get_installed_version() == server_games[game_name]->l1->GetLatestVersion() ||
-    // server_games[game_name]->l1->force_verify){
-    //   server_games[game_name]->l1->verify();
-    // }
-    // else {
-    //  server_games[game_name]->l1->update();
-    //}
+    A_printf("[Palace/UpdateGame] Updating %s....", game_name.c_str());
+    // stub for now
     return 0;
 }
+
+
 std::vector<std::string> palace::get_games()
 {
     auto vec = std::vector<std::string>();

--- a/winter/Code/palace/palace.hpp
+++ b/winter/Code/palace/palace.hpp
@@ -22,7 +22,7 @@ class palace
     void download_assets();
     int init_games();
     int update_game(const std::string &game_name);
-    int update_game_with_path(const std::string &game_name, std::string custom_path);
+    int update_game(const std::string &game_name,const std::string &install_path);
     int verify_game(const std::string &game_name);
     int launch_game(const std::string &game_name, const std::string &arguments);
     bool is_app_installed(const std::string &app_id);


### PR DESCRIPTION
This was initially going to be a quick fix; just add the symlink and refactor the `in_path` functions. However I've realised that the Kachemak implementation depends on the `sourcemod_path` and *not* the actual game directory. 

Ideally palace should create the directory and purview of the versioning module (in this case the Kachemak implementation in Emley) should purely exist within that folder.