### PR TITLE
Enable size checks

### DIFF
--- a/winter/Code/emley/kachemak/kachemak.hpp
+++ b/winter/Code/emley/kachemak/kachemak.hpp
@@ -12,7 +12,7 @@
 struct KachemakVersion
 {
   std::string file_name;
-  std::string download_url;
+  std::string download_url_p2p;
   std::size_t download_size;
   std::size_t extract_size;
   std::string version;
@@ -24,6 +24,7 @@ struct KachemakPatch
   std::string url;
   std::string filename;
   std::size_t temp_required;
+
 };
 
 enum class FreeSpaceCheckCategory

--- a/winter/Code/palace/palace.cpp
+++ b/winter/Code/palace/palace.cpp
@@ -179,7 +179,7 @@ int palace::update_game(const std::string &game_name)
     // }
     else
     {
-        server_games[game_name]->l1->update();
+        return server_games[game_name]->l1->update();
     }
     return 0;
 }


### PR DESCRIPTION
Size checks were(?) enabled at one point but they've always been iffy cause the server side (i.e me manually going in) just bodged the size data. Now that bullseye might be generated server-side, it's a good time to re-enable them. 
Note that this also needs to be displayed on the UI somehow.