### PR TITLE
Add termination handler, error levels

### DIFF
--- a/belmont/init.gd
+++ b/belmont/init.gd
@@ -1,9 +1,17 @@
 extends Control
 var oops = preload("res://oops.tscn")
+var panic = preload("res://panic.tscn")
 
 var spin_tween: Tween
 var s: binding
 
+const ErrorLevel = {
+	INFO = 0,
+	WARNING = 1,
+	SERIOUS = 2,
+	OOPS = 3,
+	PANIC = 4
+}
 
 func _ready():
 	s = binding.new()
@@ -59,9 +67,15 @@ func transition():
 
 
 	
-func _on_error(error_detail):
-	print(error_detail)
-	var z = oops.instantiate()
+func _on_error(error_level,error_detail):
+	if error_level < ErrorLevel.OOPS:
+		print(error_detail)
+		return
+	var z
+	if error_level == ErrorLevel.OOPS:
+		z = oops.instantiate()
+	elif error_level == ErrorLevel.PANIC:
+		z = panic.instantiate()
 	z.find_child("Label2").set("text",error_detail)
 	get_tree().get_root().call_deferred("add_child",z)
 	await get_tree().create_timer(1).timeout

--- a/belmont/panic.tscn
+++ b/belmont/panic.tscn
@@ -22,7 +22,7 @@ script = ExtResource("1_v8uiu")
 material = SubResource("CanvasItemMaterial_2ld2c")
 layout_mode = 0
 offset_right = 770.0
-offset_bottom = 350.0
+offset_bottom = 352.0
 color = Color(0.713726, 0.207843, 0.219608, 1)
 metadata/_edit_group_ = true
 
@@ -73,3 +73,4 @@ theme_override_font_sizes/font_size = 27
 text = "Error: -1 (Error has not been inputted.)
 "
 horizontal_alignment = 1
+autowrap_mode = 3

--- a/winter/Code/binding/binding.cpp
+++ b/winter/Code/binding/binding.cpp
@@ -28,7 +28,15 @@ void binding::_bind_methods()
 
 binding::binding()
 {
-    UtilityFunctions::print("[binding] Initialised. Ready to fire up palace.");
+    A_init_error_system();
+    A_error_system->register_listener(EventType::OnError, [this](Event &ev) { emit_signal("error", String(static_cast<ErrorMessage &>(ev).get_message().c_str())); });
+    UtilityFunctions::print("[binding/init] Error system initialised. Ready to fire up palace.");
+    std::set_terminate([]()
+    {
+        A_error("EXCEPTION NOT HANDLED.... EXPLODING IN 5 SECONDS");
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+        abort();
+    });
 }
 
 Dictionary binding::get_game_assets(String game_name)
@@ -74,8 +82,7 @@ void binding::init_palace()
 
 void binding::_init_palace()
 {
-    A_init_error_system();
-    A_error_system->register_listener(EventType::OnError, [this](Event &ev) { emit_signal("error", String(static_cast<ErrorMessage &>(ev).get_message().c_str())); });
+
     UtilityFunctions::print("[binding] Firing up palace!");
     try
     {

--- a/winter/Code/binding/binding.cpp
+++ b/winter/Code/binding/binding.cpp
@@ -8,7 +8,7 @@ void binding::_bind_methods()
     ADD_SIGNAL(MethodInfo("game_updated", PropertyInfo(Variant::STRING, "status"), PropertyInfo(Variant::STRING, "game")));
     ADD_SIGNAL(MethodInfo("progress_update", PropertyInfo(Variant::FLOAT, "progress"), PropertyInfo(Variant::STRING, "game")));
     ADD_SIGNAL(MethodInfo("palace_started"));
-    ADD_SIGNAL(MethodInfo("error", PropertyInfo(Variant::STRING, "error_details")));
+    ADD_SIGNAL(MethodInfo("error", PropertyInfo(Variant::STRING, "error_details"), PropertyInfo(Variant::INT, "error_level")));
     ClassDB::bind_method(D_METHOD("desktop_notification"), &binding::desktop_notification);
     ClassDB::bind_method(D_METHOD("init_palace"), &binding::init_palace);
     ClassDB::bind_method(D_METHOD("sanity_checks"), &binding::sanity_checks);
@@ -29,14 +29,16 @@ void binding::_bind_methods()
 binding::binding()
 {
     A_init_error_system();
-    A_error_system->register_listener(EventType::OnError, [this](Event &ev) { emit_signal("error", String(static_cast<ErrorMessage &>(ev).get_message().c_str())); });
+    A_error_system->register_listener(EventType::OnError,
+                                      [this](Event &ev) { emit_signal("error", static_cast<ErrorMessage &>(ev).get_error_level(), String(static_cast<ErrorMessage &>(ev).get_message().c_str())); });
     UtilityFunctions::print("[binding/init] Error system initialised. Ready to fire up palace.");
-    std::set_terminate([]()
-    {
-        A_error("EXCEPTION NOT HANDLED.... EXPLODING IN 5 SECONDS");
-        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
-        abort();
-    });
+    std::set_terminate(
+        []()
+        {
+            A_error(ErrorLevel::PANIC, "EXCEPTION NOT HANDLED.... EXPLODING IN 5 SECONDS");
+            std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+            abort();
+        });
 }
 
 Dictionary binding::get_game_assets(String game_name)
@@ -82,7 +84,7 @@ void binding::init_palace()
 
 void binding::_init_palace()
 {
-
+    throw 1;
     UtilityFunctions::print("[binding] Firing up palace!");
     try
     {
@@ -90,7 +92,7 @@ void binding::_init_palace()
     }
     catch (std::runtime_error &e)
     {
-        A_error(e.what());
+        A_error(ErrorLevel::PANIC, e.what());
         return;
     }
     emit_signal("palace_started");
@@ -145,11 +147,11 @@ int binding::init_games()
     for (auto i : p->server_games)
     {
         i.second->l1->event_system.register_listener(EventType::OnUpdate,
-                                                       [this, i](Event &ev)
-                                                       {
-                                                           double prog = ((ProgressUpdateMessage &)ev).get_progress();
-                                                           emit_signal("progress_update", i.first.c_str(), prog);
-                                                       });
+                                                     [this, i](Event &ev)
+                                                     {
+                                                         double prog = ((ProgressUpdateMessage &)ev).get_progress();
+                                                         emit_signal("progress_update", i.first.c_str(), prog);
+                                                     });
     }
     return ret;
 }

--- a/winter/Code/emley/kachemak/kachemak.cpp
+++ b/winter/Code/emley/kachemak/kachemak.cpp
@@ -199,7 +199,7 @@ int Kachemak::install()
     int download_status = torrent::libtorrent_download(download_uri, temp_path.string(), &event_system);
     if (download_status != 0)
     {
-        A_error("[Kachemak/install] Download failed - ret val %d \n", download_status);
+        A_error(ErrorLevel::SERIOUS,"[Kachemak/install] Download failed - ret val %d \n", download_status);
         return download_status;
     }
     A_printf("[Kachemak/install] Download complete: extracting...");
@@ -237,7 +237,7 @@ int Kachemak::install_path(std::filesystem::path custom_path)
     // true,&event_system);
     if (download_status != 0)
     {
-        A_error("[Kachemak/InstallInPath] Download failed - ret val %d \n", download_status);
+        A_error(ErrorLevel::SERIOUS,"[Kachemak/InstallInPath] Download failed - ret val %d \n", download_status);
         return download_status;
     }
     A_printf("[Kachemak/InstallInPath] Download complete: extracting...");
@@ -272,7 +272,7 @@ int Kachemak::extract(const std::string &input_file, const std::string &output_d
     int ret = sys::extract_zip((temp_path / input_file).string(), output_directory);
     if (ret != 0)
     {
-        A_error("[Kachemak/extract] Extraction Failed - %s\n", zip_strerror(ret));
+        A_error(ErrorLevel::SERIOUS,"[Kachemak/extract] Extraction Failed - %s\n", zip_strerror(ret));
         return -1;
     }
     installed_version_code = get_latest_version_code();
@@ -294,7 +294,7 @@ int Kachemak::extract_path(const std::string &input_file, const std::string &out
     int ret = sys::extract_zip((temp_path / input_file).string(), output_directory);
     if (ret != 0)
     {
-        A_error("[Kachemak/ExtractInPath] Extraction Failed - %s\n", zip_strerror(ret));
+        A_error(ErrorLevel::SERIOUS,"[Kachemak/ExtractInPath] Extraction Failed - %s\n", zip_strerror(ret));
         return -1;
     }
     installed_version_code = get_latest_version_code();
@@ -438,7 +438,7 @@ int Kachemak::butler_parse_command(const std::string &command)
             }
             else if (message_type.compare("error") == NULL)
             {
-                ErrorMessage message(json_buffer["message"].get<std::string>());
+                ErrorMessage message(json_buffer["message"].get<std::string>(),ErrorLevel::PANIC);
                 event_system.trigger_event(message);
             }
         }

--- a/winter/Code/palace/palace.cpp
+++ b/winter/Code/palace/palace.cpp
@@ -41,7 +41,7 @@ void palace::fetch_server_data()
     }
     catch (nlohmann::json::parse_error &ex)
     {
-        A_error("Can't fetch southbank. Check your internet connection!");
+        A_error(ErrorLevel::PANIC,"Can't fetch southbank. Check your internet connection!");
     }
 }
 
@@ -257,7 +257,7 @@ int palace::launch_game(const std::string &game_name, const std::string &argumen
     std::filesystem::path sdk_app_path = get_app_path(SOURCE_SDK_2013_APP_ID);
     if (!std::filesystem::exists(sdk_app_path))
     {
-        A_error("[Palace/launch_game] sdk path doesn't exist...");
+        A_error(ErrorLevel::SERIOUS,"[Palace/launch_game] sdk path doesn't exist...");
         return 1;
     }
 #ifdef WIN32

--- a/winter/Code/palace/palace.cpp
+++ b/winter/Code/palace/palace.cpp
@@ -270,7 +270,7 @@ int palace::launch_game(const std::string &game_name, const std::string &argumen
 
     if (CreateProcessA(sdk_app_binary.c_str(), command_line, NULL, NULL, FALSE, NORMAL_PRIORITY_CLASS, NULL, (LPSTR)sourcemods_path.string().c_str(), &dummy_si, &dummy_pi) == 0)
     {
-        A_error("[Palace/launch_game] win32: CreateProcessA failed!");
+        A_error(ErrorLevel::SERIOUS,"[Palace/launch_game] win32: CreateProcessA failed!");
         return 1;
     }
 #else

--- a/winter/Code/shared/adastral_defs.hpp
+++ b/winter/Code/shared/adastral_defs.hpp
@@ -15,14 +15,8 @@
 #endif
 
 inline EventSystem *A_error_system;
-enum error_level
-{
-    INFO,
-    WARNING,
-    SERIOUS,
-    PANIC
-};
-inline std::map<error_level, std::string> error_string_map{{INFO, "info"}, {WARNING, "warning"}, {SERIOUS, "serious"}, {PANIC, "panic"}};
+
+//inline std::map<error_level, std::string> error_string_map{{INFO, "info"}, {WARNING, "warning"}, {SERIOUS, "serious"}, {PANIC, "panic"}};
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #define popen _popen
 #define BUTLER "butler.exe"
@@ -45,13 +39,13 @@ template <typename... Args> std::string string_format(const std::string &format,
     std::snprintf(buf.get(), size, format.c_str(), args...);
     return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
-template <typename... Args> void A_error(const std::string &format, Args... args)
+template <typename... Args> void A_error(ErrorLevel error_level, const std::string &format, Args... args)
 {
     std::string error_detail = string_format(format, args...);
     A_printf("### ERROR: %s", error_detail.c_str());
 #ifndef GODOT
 #else
-    ErrorMessage e = ErrorMessage(std::move(error_detail));
+    ErrorMessage e = ErrorMessage(std::move(error_detail),error_level);
     A_error_system->trigger_event(e);
 #endif
 }

--- a/winter/Code/shared/events/error.cpp
+++ b/winter/Code/shared/events/error.cpp
@@ -1,11 +1,18 @@
 #include <error.hpp>
+#include <utility>
 
-ErrorMessage::ErrorMessage(std::string message) : Event(EventType::OnError)
+ErrorMessage::ErrorMessage(std::string message, ErrorLevel error_level) : Event(EventType::OnError)
 {
-    this->message = message;
+    this->message = std::move(message);
+    this->error_level = error_level;
 }
 
 const std::string &ErrorMessage::get_message()
 {
-    return message;
+    return this->message;
+}
+
+const ErrorLevel &ErrorMessage::get_error_level()
+{
+    return this->error_level;
 }

--- a/winter/Code/shared/events/error.hpp
+++ b/winter/Code/shared/events/error.hpp
@@ -2,12 +2,24 @@
 
 #include "event.hpp"
 
+enum ErrorLevel
+{
+    INFO = 0,
+    WARNING = 1,
+    SERIOUS = 2,
+    OOPS = 3,
+    PANIC = 4
+};
+
+
 class ErrorMessage : public Event
 {
   public:
-    ErrorMessage(std::string message);
+    ErrorMessage(std::string message, ErrorLevel error_level);
     const std::string &get_message();
+    const ErrorLevel &get_error_level();
 
   private:
+    ErrorLevel error_level;
     std::string message;
 };

--- a/winter/Code/sys/sys.cpp
+++ b/winter/Code/sys/sys.cpp
@@ -100,7 +100,7 @@ std::filesystem::path sys::get_steam_path()
     if (valueData[0] == 0)
     {
         // Registry key did not exist/had no value
-        A_error("Steam not detected!");
+        A_error(ErrorLevel::OOPS,"Steam not detected!");
         return std::filesystem::path();
     }
 

--- a/winter/Code/sys/sys.cpp
+++ b/winter/Code/sys/sys.cpp
@@ -12,7 +12,7 @@ int sys::exec_with_param(const std::vector<std::string> &params)
     return system(param_str.c_str());
 }
 
-/*
+/**
 description:
   recursively delete contents of directory
 res:
@@ -117,7 +117,7 @@ std::filesystem::path sys::get_steam_path()
     {
         return std::filesystem::canonical(path_flatpak);
     }
-    A_error("Steam not detected!");
+    A_error(ErrorLevel::OOPS,"Steam not detected!");
     return std::filesystem::path("");
 #endif
 }

--- a/winter/Code/torrent/torrent.cpp
+++ b/winter/Code/torrent/torrent.cpp
@@ -109,7 +109,7 @@ done:
 }
 catch (std::exception &e)
 {
-    A_error(e.what());
+    A_error(ErrorLevel::OOPS,e.what());
     A_printf("[torrent] Error: %s", e.what());
     return 1;
 }


### PR DESCRIPTION
Pretty much what it says on the tin. Using ``set_terminate``, we can display any fatal errors to the user before exploding. Finally implementing error levels - it's something I've wanted to do for a bit. This allows for finer-grain error handling in the UI, and overall.